### PR TITLE
Lock the boxes to older versions that still have Puppet 3.x

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ require 'yaml'
 require 'rbconfig'
 
 params = YAML::load_file('./default.config.yaml')
- 
+
 # Load new configuration files.
 begin
   params = params.merge YAML::load_file('./config.yaml')
@@ -33,6 +33,7 @@ Vagrant.configure('2') do |config|
   config.vm.network :private_network, ip: params['private_ip']
 
   config.vm.box = params['box']
+  config.vm.box_url = params['box_url']
 
   config.ssh.forward_agent = true
 

--- a/default.config.yaml
+++ b/default.config.yaml
@@ -3,10 +3,13 @@ hostname: "local"
 # The private IP to provision for this host.
 private_ip: "33.33.33.40"
 # The base box to use to build the puppet work on top of.
-# Commetning out the line below (or overriding in config,yaml)
-# to switch to 12.04 should also work.
-box: "puppetlabs/ubuntu-14.04-64-puppet" 
-#box: puppetlabs/ubuntu-12.04-64-puppet
+# Commenting out the two lines below (or overriding in config,yaml)
+# to switch to 12.04.
+box: "puppetlabs/ubuntu-14.04-64-puppet-1.0.0"
+box_url: "https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-14.04-64-puppet/versions/1.0.0/providers/virtualbox.box"
+# Comment out the next two lines, to use 12.04
+#box: "puppetlabs/ubuntu-12.04-64-puppet-1.0.0"
+#box_url: "https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-12.04-64-puppet/versions/1.0.0/providers/virtualbox.box"
 # The amount of memory (in megabytes) to provision.
 memory: "2048"
 # Set this to false in order to not mount the www folder in this


### PR DESCRIPTION
This locks the box version to an older release that has Puppet 3.x since newer version of the puppetlabs boxes contain Puppet 4.x, which isn't compatible.