### PR TITLE
Updating drupal-patchfile source and git_ref until PR is merged for f…

### DIFF
--- a/custom-modules/drush_patchfile/manifests/init.pp
+++ b/custom-modules/drush_patchfile/manifests/init.pp
@@ -4,7 +4,7 @@ class drush_patchfile ($git_ref = 'master') {
     require  => Class['drush'],
     ensure   => present,
     provider => git,
-    source   => "https://bitbucket.org/davereid/drush-patchfile.git",
+    source   => "https://bitbucket.org/szeidler/drush-patchfile.git",
     revision => $git_ref,
   }
 

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -10,7 +10,7 @@ drupal_php::upload_max_filesize: 200M
 drupal_php::display_errors : 'On'
 drupal_php::log_errors: 'On'
 drupal_php::timezone: 'GMT'
-drush_patchfile::git_ref: 'e7ffe4ccbb4c7c768788d0c24e6a18835eb35f74'
+drush_patchfile::git_ref: '25ccc3683a32da867126a6e17e21524d9b054151'
 drush::configs:
   patch-file:
     value: patches.make


### PR DESCRIPTION
…ix for D8.

**To Test**

- [ ] Checkout drush-patchfile-patch branch on your VM or build a new VM from this branch.

- [ ] Provision your VM.

- [ ] Do a `drush ps` inside of a Drupal 8.2.x fresh site install that has a valid patches.make file. ([This bear PR](https://github.com/zivtech/bear/pull/210) will work great for this test and can kill 2 PRs with one review.)