### PR TITLE
Switch to prefork mpm module

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -8,7 +8,7 @@ drupal_php::log_errors: true
 drupal_php::max_execution_time_server: 30
 drupal_php::memory_limit_server: 256M
 drupal_php::post_max_size: '8M'
-drupal_php::server::apache::mpm_module: event
+drupal_php::server::apache::mpm_module: prefork
 drupal_php::timezone: 'GMT'
 drupal_php::upload_max_filesize: 200M
 php::globals::php_version: '7.1'


### PR DESCRIPTION
Another module is loading the prefork module. Apache cannot have two MPM modules enabled at the same time. Thus, if we want to use the event MPM module, then first someone should track down where the prefork module is being enabled and prevent it. In the meantime, to make this VM work, we must specify the prefork MPM module.