### PR TITLE
Fix mhsendmail php.ini setting.

### DIFF
--- a/custom-modules/mailhog/manifests/init.pp
+++ b/custom-modules/mailhog/manifests/init.pp
@@ -58,13 +58,15 @@ class mailhog {
   }
 
   file_line { 'mhsendmail php.ini':
-    ensure => present,
-    path   => '/etc/php/7.1/fpm/php.ini',
-    line   => 'sendmail_path = /usr/local/bin/mhsendmail',
-    match  => '^;?sendmail_path',
-    notify => [
+    ensure  => present,
+    path    => '/etc/php/7.1/fpm/php.ini',
+    line    => 'sendmail_path = /usr/local/bin/mhsendmail',
+    match   => '^;?sendmail_path',
+    require => Class['drupal_php::fpm'],
+    notify  => [
       Service['httpd'],
       Service['php7.1-fpm'],
+      Class['::php::fpm::service'],
     ],
   }
 

--- a/custom-modules/mailhog/manifests/init.pp
+++ b/custom-modules/mailhog/manifests/init.pp
@@ -57,4 +57,15 @@ class mailhog {
     source => '/usr/local/bin/mhsendmail',
   }
 
+  file_line { 'mhsendmail php.ini':
+    ensure => present,
+    path   => '/etc/php/7.1/fpm/php.ini',
+    line   => 'sendmail_path = /usr/local/bin/mhsendmail',
+    match  => '^;?sendmail_path',
+    notify => [
+      Service['httpd'],
+      Service['php7.1-fpm'],
+    ],
+  }
+
 }


### PR DESCRIPTION
We hadn't switched the php.ini settings to use the proper
sendmail binary after switching from standard sendmail to the
mailhog sendmail binary. This caused emails to fail to be
properly picked up by the VM.