### PR TITLE
Prevent error or vagrant reload.

### DIFF
--- a/custom-modules/mailhog/manifests/init.pp
+++ b/custom-modules/mailhog/manifests/init.pp
@@ -1,12 +1,20 @@
 class mailhog {
 
   package { 'postfix':
-    ensure => 'present',
+    ensure => 'absent',
   }->
 
-  service { 'postfix':
-    ensure => 'running',
-  }
+  file { '/etc/network/if-up.d/postfix':
+    ensure => 'present',
+    mode   => '0755',
+    content => "#! /bin/bash\nexit 0",
+  }->
+
+  file { '/etc/network/if-down.d/postfix':
+    ensure => 'present',
+    mode   => '0755',
+    content => "#! /bin/bash\nexit 0",
+  }->
 
   wget::fetch { 'download mailhog':
     source      => 'https://github.com/mailhog/MailHog/releases/download/v1.0.0/MailHog_linux_amd64',


### PR DESCRIPTION
In some cases vagrant would fail to reload a vm due to issues
with the postfix configuration. However we actually don't appear
to need or use postfix on the vm and instead route php mail
through mhsendmail to mailhog. As a result postfix can be removed
and the failing scripts can be replaced with a fast `exit 0`
command.

## To test
- spin up a new VM on this branch
- as soon as it is booted run `vagrant reload`
- ensure the machine comes back up without any errors.